### PR TITLE
README: make uuidgen OSX friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The simplest way is to use `kubectl run`.
 kubectl run spartakus \
     --image=gcr.io/google_containers/spartakus-amd64:v1.0.0 \
     -- \
-    volunteer --cluster-id=$(uuidgen -r)
+    volunteer --cluster-id=$(uuidgen)
 ```
 
 This will generate a `Deployment` called "spartakus" in your "default"


### PR DESCRIPTION
On OSX uuidgen doesn't have `-r` and on linux `-r` is default. Just
remove the flag.
