### PR TITLE
Add timestamp to all reports

### DIFF
--- a/pkg/collector/api.go
+++ b/pkg/collector/api.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/julienschmidt/httprouter"
@@ -89,7 +88,6 @@ func (s *APIServer) storeRecordHandler() httprouter.Handle {
 			writeError(w, http.StatusBadRequest, fmt.Errorf("failed to decode record: %v", err))
 			return
 		}
-		rec.Timestamp = strconv.FormatInt(time.Now().Unix(), 10)
 		s.logRecord(&rec)
 
 		if err := s.Database.Store(rec); err != nil {

--- a/pkg/volunteer/volunteer.go
+++ b/pkg/volunteer/volunteer.go
@@ -18,6 +18,7 @@ package volunteer
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/kubernetes-incubator/spartakus/pkg/database"
@@ -104,6 +105,7 @@ func (v *volunteer) generateRecord() (report.Record, error) {
 
 	rec := report.Record{
 		Version:       version.VERSION,
+		Timestamp:     strconv.FormatInt(time.Now().Unix(), 10),
 		ClusterID:     v.clusterID,
 		MasterVersion: &svrVer,
 		Nodes:         nodes,


### PR DESCRIPTION
Currently, the `timestamp` field is only added to reports that are
processed with a Spartakus collector. If you run the volunteer with
`--database=stdout` or even `--database=bigquery://...` your records
will have no timestamp. This commit adds the timestamp field to reports
at the time of creation in the volunteer.