### PR TITLE
report: add cloud provider name to report

### DIFF
--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -54,6 +54,9 @@ type Node struct {
 	ContainerRuntimeVersion *string `json:"containerRuntimeVersion,omitempty"`
 	// KubeletVersion is the value reported by kubernetes in the node status.
 	KubeletVersion *string `json:"kubeletVersion,omitempty"`
+	// CloudProvider is the <ProviderName> portion of the ProviderID reported
+	// by kubernetes in the node spec.
+	CloudProvider *string `json:"cloudProvider,omitempty"`
 	// Capacity is a list of resources and their associated values as reported
 	// by kubernetes in the node status.
 	Capacity []Resource `json:"capacity,omitempty"`

--- a/pkg/volunteer/kubernetes.go
+++ b/pkg/volunteer/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"sort"
+	"strings"
 
 	"github.com/kubernetes-incubator/spartakus/pkg/report"
 	kclient "k8s.io/client-go/1.4/kubernetes"
@@ -45,6 +46,7 @@ func nodeFromKubeNode(kn *kv1.Node) report.Node {
 		Architecture:            strPtr(kn.Status.NodeInfo.Architecture),
 		ContainerRuntimeVersion: strPtr(kn.Status.NodeInfo.ContainerRuntimeVersion),
 		KubeletVersion:          strPtr(kn.Status.NodeInfo.KubeletVersion),
+		CloudProvider:           strPtr(providerName(kn.Spec.ProviderID)),
 	}
 	// We want to iterate the resources in a deterministic order.
 	keys := []string{}
@@ -83,6 +85,18 @@ func strPtr(str string) *string {
 	p := new(string)
 	*p = str
 	return p
+}
+
+// providerName extracts the cloud provider name from a given
+// string that should match: <ProviderName>://<ProviderSpecficNodeID>
+// (see https://github.com/kubernetes/client-go/blob/v1.4.0/1.4/pkg/api/v1/types.go#L2446).
+// If the given string does not match this format, we return "unknown".
+func providerName(providerID string) string {
+	parts := strings.Split(providerID, "://")
+	if len(parts) != 2 {
+		return "unknown"
+	}
+	return parts[0]
 }
 
 func newKubeClientWrapper() (*kubeClientWrapper, error) {

--- a/pkg/volunteer/kubernetes_test.go
+++ b/pkg/volunteer/kubernetes_test.go
@@ -37,7 +37,9 @@ func TestNodeFromKubeNode(t *testing.T) {
 					Name: "kname",
 				},
 			},
-			expect: report.Node{},
+			expect: report.Node{
+				CloudProvider: strPtr("unknown"),
+			},
 		},
 		{
 			input: kv1.Node{
@@ -59,6 +61,7 @@ func TestNodeFromKubeNode(t *testing.T) {
 					{Resource: "r2", Value: "200"},
 					{Resource: "r3", Value: "300"},
 				},
+				CloudProvider: strPtr("unknown"),
 			},
 		},
 		{
@@ -84,6 +87,7 @@ func TestNodeFromKubeNode(t *testing.T) {
 				Architecture:            strPtr("architecture"),
 				ContainerRuntimeVersion: strPtr("runtime"),
 				KubeletVersion:          strPtr("kubelet"),
+				CloudProvider:           strPtr("unknown"),
 			},
 		},
 	}


### PR DESCRIPTION
This commit modifies the Node struct and adds a new field
`CloudProvider`. This value is determined by taking the `<ProviderName>`
portion of the `ProviderID` reported in the node spec. Making this
change will require updating the database schema. The cloud provider
name is not PII and will provide useful insight into how people are using
Kubernetes.

Addresses: #14