### PR TITLE
report: add cloud provider name to report

### DIFF
--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -54,6 +54,9 @@ type Node struct {
 	ContainerRuntimeVersion *string `json:"containerRuntimeVersion,omitempty"`
 	// KubeletVersion is the value reported by kubernetes in the node status.
 	KubeletVersion *string `json:"kubeletVersion,omitempty"`
+	// CloudProvider is the <ProviderName> portion of the ProviderID reported
+	// by kubernetes in the node spec.
+	CloudProvider *string `json:"cloudProvider,omitempty"`
 	// Capacity is a list of resources and their associated values as reported
 	// by kubernetes in the node status.
 	Capacity []Resource `json:"capacity,omitempty"`

--- a/pkg/volunteer/kubernetes_test.go
+++ b/pkg/volunteer/kubernetes_test.go
@@ -32,12 +32,20 @@ func TestNodeFromKubeNode(t *testing.T) {
 		expect report.Node
 	}{
 		{
+			input: kv1.Node{},
+			expect: report.Node{
+				CloudProvider: strPtr("unknown"),
+			},
+		},
+		{
 			input: kv1.Node{
 				ObjectMeta: kv1.ObjectMeta{
 					Name: "kname",
 				},
 			},
-			expect: report.Node{},
+			expect: report.Node{
+				CloudProvider: strPtr("unknown"),
+			},
 		},
 		{
 			input: kv1.Node{
@@ -59,6 +67,7 @@ func TestNodeFromKubeNode(t *testing.T) {
 					{Resource: "r2", Value: "200"},
 					{Resource: "r3", Value: "300"},
 				},
+				CloudProvider: strPtr("unknown"),
 			},
 		},
 		{
@@ -84,6 +93,27 @@ func TestNodeFromKubeNode(t *testing.T) {
 				Architecture:            strPtr("architecture"),
 				ContainerRuntimeVersion: strPtr("runtime"),
 				KubeletVersion:          strPtr("kubelet"),
+				CloudProvider:           strPtr("unknown"),
+			},
+		},
+		{
+			input: kv1.Node{
+				Spec: kv1.NodeSpec{
+					ProviderID: "foo://bar",
+				},
+			},
+			expect: report.Node{
+				CloudProvider: strPtr("unknown"),
+			},
+		},
+		{
+			input: kv1.Node{
+				Spec: kv1.NodeSpec{
+					ProviderID: "aws://foo",
+				},
+			},
+			expect: report.Node{
+				CloudProvider: strPtr("aws"),
 			},
 		},
 	}


### PR DESCRIPTION
This commit modifies the Node struct and adds a new field
`CloudProvider`. This value is determined by taking the `<ProviderName>`
portion of the `ProviderID` reported in the node spec. Making this
change will require updating the database schema. The cloud provider
name is checked against a whitelist of know cloud providers to avoid
leaking any PII.

This PR re-opens the discussion from #15 with the discussed whitelist.