### PR TITLE
README,database: fix missing occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ An example of a report payload:
             "architecture": "amd64",
             "containerRuntimeVersion": "docker://1.11.2",
             "kubeletVersion": "v1.3.2",
+            "cloudProvider": "aws",
             "capacity": [
                 {
                     "resource": "alpha.kubernetes.io/nvidia-gpu",
@@ -81,6 +82,7 @@ An example of a report payload:
             "architecture": "amd64",
             "containerRuntimeVersion": "docker://1.11.2",
             "kubeletVersion": "v1.3.2",
+            "cloudProvider": "aws",
             "capacity": [
                 {
                     "resource": "alpha.kubernetes.io/nvidia-gpu",

--- a/pkg/database/bigquery.go
+++ b/pkg/database/bigquery.go
@@ -148,6 +148,7 @@ func makeNode(node report.Node) map[string]bigquery.JsonValue {
 		"architecture":            node.Architecture,
 		"containerRuntimeVersion": node.ContainerRuntimeVersion,
 		"kubeletVersion":          node.KubeletVersion,
+		"cloudProvider":           node.CloudProvider,
 	}
 	capacity := []map[string]bigquery.JsonValue{}
 	for _, c := range node.Capacity {


### PR DESCRIPTION
This commit fixes some missing occurrences of `cloudProvider`, namely in
in the README and the database package. Without these changes the
cloudProvider will not be sent to bigquery. It also updates the example
report in the README to show the new field that is submitted.