### PR TITLE
Add extensions reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,15 @@ So, don't be afraid about its CPU/mem usage :)
 
 ## Extensions
 
-Reports can be voluntarily extended to include additional information by
-running the volunteer with the `--extensions` flag.  This flag should be set to
-the path of a file of arbitrary JSON key-value pairs you would like to report,
-e.g.:
+Reports can be voluntarily extended to include additional information called
+*extensions*. Extensions are key-value pairs. Valid keys have two segments: an
+optional prefix and a name, separated by a slash (`/`). The name segment is
+required and the prefix is optional. If specified, the prefix must be a DNS
+subdomain: a series of DNS labels separated by dots (`.`), e.g. "example.com".
+
+In order to submit extensions, run the volunteer with the `--extensions` flag.
+This flag should be set to the path of a file of arbitrary JSON key-value pairs
+you would like to report, e.g.:
 
 ```
 spartakus volunteer --cluster-id=$(uuidgen) --extensions=/path/to/my/extensions.json
@@ -165,8 +170,8 @@ Where `extensions.json` could be:
 
 ```json
 {
-  "hello": "world",
-  "foo": "bar"
+  "example.com/hello": "world",
+  "example.com/foo": "bar"
 }
 ```
 
@@ -180,16 +185,20 @@ With this configuration, the volunteer will generate a report that looks like:
     "masterVersion": "v1.3.5",
     "extensions": [
       {
-        "name": "hello",
+        "name": "example.com/hello",
         "value": "world"
       },
       {
-        "name": "foo",
+        "name": "example.com/foo",
         "value": "bar"
       }
     ]
 }
 ```
+
+The `--extensions` flag can optionally be set to the path of a directory. In
+this case, all files in the provided directory, excluding those with a leading
+`.`, will be parsed.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,47 @@ totally fine with `1m` CPU and `10Mi` mem on a 5 nodes cluster.
 
 So, don't be afraid about its CPU/mem usage :)
 
+## Extensions
+
+Reports can be voluntarily extended to include additional information by
+running the volunteer with the `--extensions` flag.  This flag should be set to
+the path of a file of arbitrary JSON key-value pairs you would like to report,
+e.g.:
+
+```
+spartakus volunteer --cluster-id=$(uuidgen) --extensions=/path/to/my/extensions.json
+```
+
+Where `extensions.json` could be:
+
+```json
+{
+  "hello": "world",
+  "foo": "bar"
+}
+```
+
+With this configuration, the volunteer will generate a report that looks like:
+
+```json
+{
+    "version": "v1.0.0",
+    "timestamp": "867530909031976",
+    "clusterID": "2f9c93d3-156c-47aa-8802-578ffca9b50e",
+    "masterVersion": "v1.3.5",
+    "extensions": [
+      {
+        "name": "hello",
+        "value": "world"
+      },
+      {
+        "name": "foo",
+        "value": "bar"
+      }
+    ]
+}
+```
+
 ## Development
 
 Simply run `make` or `make test`.  The build is done through Docker.

--- a/cmd/spartakus/volunteer.go
+++ b/cmd/spartakus/volunteer.go
@@ -32,6 +32,7 @@ var volunteerConfig = struct {
 	period         time.Duration
 	database       string
 	printDatabases bool
+	extensionsPath string
 }{}
 
 type volunteerSubProgram struct{}
@@ -42,6 +43,7 @@ func (_ volunteerSubProgram) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&volunteerConfig.database, "database",
 		"https://spartakus.k8s.io", "Send reports to this database; use --print-databases for a list of options")
 	fs.BoolVar(&volunteerConfig.printDatabases, "print-databases", false, "Print database options and exit")
+	fs.StringVar(&volunteerConfig.extensionsPath, "extensions", "", "Path to a file of additional metrics to report; leave unset to report no additional metrics")
 }
 
 func (_ volunteerSubProgram) Validate() error {
@@ -65,7 +67,7 @@ func (_ volunteerSubProgram) Main(log logr.Logger) error {
 		return fmt.Errorf("failed to initialize database: %v", err)
 	}
 
-	volunteer, err := volunteer.New(log, volunteerConfig.clusterID, volunteerConfig.period, db)
+	volunteer, err := volunteer.New(log, volunteerConfig.clusterID, volunteerConfig.period, db, volunteerConfig.extensionsPath)
 	if err != nil {
 		return fmt.Errorf("failed initializing volunteer: %v", err)
 	}

--- a/pkg/database/bigquery.go
+++ b/pkg/database/bigquery.go
@@ -136,6 +136,11 @@ func makeRow(rec report.Record) map[string]bigquery.JsonValue {
 		nodes = append(nodes, makeNode(n))
 	}
 	row["nodes"] = nodes
+	extensions := []map[string]bigquery.JsonValue{}
+	for _, e := range rec.Extensions {
+		extensions = append(extensions, makeExtension(e))
+	}
+	row["extensions"] = extensions
 	return row
 }
 
@@ -163,4 +168,12 @@ func makeResource(res report.Resource) map[string]bigquery.JsonValue {
 		"value":    res.Value,
 	}
 	return r
+}
+
+func makeExtension(ext report.Extension) map[string]bigquery.JsonValue {
+	e := map[string]bigquery.JsonValue{
+		"name":  ext.Name,
+		"value": ext.Value,
+	}
+	return e
 }

--- a/pkg/database/bigquery.schema.json
+++ b/pkg/database/bigquery.schema.json
@@ -82,5 +82,22 @@
     "mode": "REPEATED",
     "name": "nodes",
     "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REQUIRED",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "REQUIRED",
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "extensions",
+    "type": "RECORD"
   }
 ]

--- a/pkg/report/record.go
+++ b/pkg/report/record.go
@@ -32,6 +32,8 @@ type Record struct {
 	MasterVersion *string `json:"masterVersion,omitempty"`
 	// Nodes is a list of node-specific information from the reporting cluster.
 	Nodes []Node `json:"nodes,omitempty"`
+	// Extensions is a list of key-value pairs of custom values.
+	Extensions []Extension `json:"extensions,omitempty"`
 }
 
 type Node struct {
@@ -66,5 +68,12 @@ type Resource struct {
 	// Resource is the name of the resource.
 	Resource string `json:"resource"` // required
 	// Value is the string form of the of the resource's value.
+	Value string `json:"value"` // required
+}
+
+type Extension struct {
+	// Name is the name of the extension.
+	Name string `json:"name"` // required
+	// Value is the string form of the of the extension's value.
 	Value string `json:"value"` // required
 }

--- a/pkg/volunteer/volunteer.go
+++ b/pkg/volunteer/volunteer.go
@@ -17,7 +17,9 @@ limitations under the License.
 package volunteer
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"strconv"
 	"time"
 
@@ -27,12 +29,13 @@ import (
 	"github.com/thockin/logr"
 )
 
-func New(log logr.Logger, clusterID string, period time.Duration, db database.Database) (*volunteer, error) {
+func New(log logr.Logger, clusterID string, period time.Duration, db database.Database, extensionsPath string) (*volunteer, error) {
 	kcw, err := newKubeClientWrapper()
 	if err != nil {
 		return nil, err
 	}
-	return newVolunteer(log, clusterID, period, db, kcw, kcw), nil
+	fel := fileExtensionsLister(extensionsPath)
+	return newVolunteer(log, clusterID, period, db, kcw, kcw, fel), nil
 }
 
 func newVolunteer(
@@ -41,25 +44,28 @@ func newVolunteer(
 	period time.Duration,
 	db database.Database,
 	nodeLister nodeLister,
-	serverVersioner serverVersioner) *volunteer {
+	serverVersioner serverVersioner,
+	extensionsLister extensionsLister) *volunteer {
 
 	return &volunteer{
-		log:             log,
-		clusterID:       clusterID,
-		period:          period,
-		database:        db,
-		nodeLister:      nodeLister,
-		serverVersioner: serverVersioner,
+		log:              log,
+		clusterID:        clusterID,
+		period:           period,
+		database:         db,
+		nodeLister:       nodeLister,
+		serverVersioner:  serverVersioner,
+		extensionsLister: extensionsLister,
 	}
 }
 
 type volunteer struct {
-	clusterID       string
-	period          time.Duration
-	database        database.Database
-	log             logr.Logger
-	nodeLister      nodeLister
-	serverVersioner serverVersioner
+	clusterID        string
+	period           time.Duration
+	database         database.Database
+	log              logr.Logger
+	nodeLister       nodeLister
+	serverVersioner  serverVersioner
+	extensionsLister extensionsLister
 }
 
 func (v *volunteer) Run() error {
@@ -103,12 +109,19 @@ func (v *volunteer) generateRecord() (report.Record, error) {
 		return report.Record{}, err
 	}
 
+	extensions, err := v.extensionsLister.ListExtensions()
+	if err != nil {
+		v.log.Errorf("failed to list extensions: %v", err)
+		extensions = []report.Extension{}
+	}
+
 	rec := report.Record{
 		Version:       version.VERSION,
 		Timestamp:     strconv.FormatInt(time.Now().Unix(), 10),
 		ClusterID:     v.clusterID,
 		MasterVersion: &svrVer,
 		Nodes:         nodes,
+		Extensions:    extensions,
 	}
 
 	return rec, nil
@@ -116,4 +129,62 @@ func (v *volunteer) generateRecord() (report.Record, error) {
 
 func (v *volunteer) send(rec report.Record) error {
 	return v.database.Store(rec)
+}
+
+type extensionsLister interface {
+	// ListExtensions returns a slice of report.Extensions, since that is the
+	// schema of the extensions in the database. Returning the array is nicer
+	// than returning a map since it means we don't have to encode any logic
+	// about transforming a map of extensions into an array of extensions in
+	// other parts of the the package. The format of the extensions file
+	// different from the database schema to be less verbose: writing
+	// {"k1": "v1", "k2": "v2"} is easier than [{"name": "k1", "value": "v1"}...
+	ListExtensions() ([]report.Extension, error)
+}
+
+// fileExtensionsLister is a basic implementation of the extensionsLister
+// that reads extensions from a file.
+type fileExtensionsLister string
+
+// ListExtensions returns a slice of report.Extensions containing the
+// custom extensions that the user may want to report.
+func (f fileExtensionsLister) ListExtensions() ([]report.Extension, error) {
+	var extensions []report.Extension
+
+	if f == "" {
+		return extensions, nil
+	}
+
+	extensionsBytes, err := ioutil.ReadFile(string(f))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read extensions file: %v", err)
+	}
+
+	return byteExtensionsLister(extensionsBytes).ListExtensions()
+}
+
+// byteExtensionsLister is a basic implementation of the extensionsLister
+// that reads extensions from a byte array.
+type byteExtensionsLister []byte
+
+// ListExtensions returns a slice of report.Extensions containing the
+// custom extensions that the user may want to report.
+func (b byteExtensionsLister) ListExtensions() ([]report.Extension, error) {
+	var extensions []report.Extension
+
+	if len(b) == 0 {
+		return extensions, nil
+	}
+
+	extensionsMap := make(map[string]string)
+	err := json.Unmarshal(b, &extensionsMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse extensions data: %v", err)
+	}
+
+	for k, v := range extensionsMap {
+		extensions = append(extensions, report.Extension{Name: k, Value: v})
+	}
+
+	return extensions, nil
 }

--- a/pkg/volunteer/volunteer_test.go
+++ b/pkg/volunteer/volunteer_test.go
@@ -40,6 +40,18 @@ func (fake fakeNodeLister) ListNodes() ([]report.Node, error) {
 	return fake.returnValue, fake.returnError
 }
 
+// Fake out "list extension" calls.
+type fakeExtensionLister struct {
+	returnValue []report.Extension
+	returnError error
+}
+
+var _ extensionsLister = fakeExtensionLister{}
+
+func (fake fakeExtensionLister) ListExtensions() ([]report.Extension, error) {
+	return fake.returnValue, fake.returnError
+}
+
 // Fake out "get server version" calls.
 type fakeServerVersioner struct {
 	returnValue string
@@ -60,15 +72,17 @@ func newTestVolunteer(t *testing.T) *volunteer {
 	db := database.Database(nil)
 	nodes := &fakeNodeLister{}
 	vers := &fakeServerVersioner{}
-	return newVolunteer(log, fakeClusterID, fakePeriod, db, nodes, vers)
+	exts := &fakeExtensionLister{}
+	return newVolunteer(log, fakeClusterID, fakePeriod, db, nodes, vers, exts)
 }
 
 func TestGenerateRecord(t *testing.T) {
 	testCases := []struct {
-		tweak   func(vol *volunteer)
-		errstr  string
-		version string
-		nodes   []string
+		tweak      func(vol *volunteer)
+		errstr     string
+		version    string
+		nodes      []string
+		extensions []string
 	}{
 		{ // test serverVersioner failure
 			tweak: func(vol *volunteer) {
@@ -82,15 +96,25 @@ func TestGenerateRecord(t *testing.T) {
 			},
 			errstr: "fail",
 		},
+		{ // test extensionLister failure, should not cause total failure
+			tweak: func(vol *volunteer) {
+				vol.extensionsLister.(*fakeExtensionLister).returnError = fmt.Errorf("fail")
+			},
+		},
 		{ // test success
 			tweak: func(vol *volunteer) {
 				vol.serverVersioner.(*fakeServerVersioner).returnValue = "v1.2.3"
 				vol.nodeLister.(*fakeNodeLister).returnValue = []report.Node{
 					{ID: "node1"}, {ID: "node2"},
 				}
+				vol.extensionsLister.(*fakeExtensionLister).returnValue = []report.Extension{
+					{Name: "foo", Value: "bar"},
+					{Name: "foo", Value: "baz"},
+				}
 			},
-			version: "v1.2.3",
-			nodes:   []string{"node1", "node2"},
+			version:    "v1.2.3",
+			nodes:      []string{"node1", "node2"},
+			extensions: []string{"bar", "baz"},
 		},
 	}
 
@@ -119,9 +143,112 @@ func TestGenerateRecord(t *testing.T) {
 			if len(rec.Nodes) != len(tc.nodes) {
 				t.Errorf("[%d] expected %d nodes, got %d", i, len(rec.Nodes), len(tc.nodes))
 			}
+			if len(rec.Extensions) != len(tc.extensions) {
+				t.Errorf("[%d] expected %d extensions, got %d", i, len(rec.Extensions), len(tc.extensions))
+			}
 			for j := range rec.Nodes {
 				if rec.Nodes[j].ID != tc.nodes[j] {
 					t.Errorf("[%d] expected node[%d].ID %q, got %q", i, j, rec.Nodes[j].ID, tc.nodes[j])
+				}
+			}
+			for j := range rec.Extensions {
+				if rec.Extensions[j].Value != tc.extensions[j] {
+					t.Errorf("[%d] expected extension[%d].Value %q, got %q", i, j, rec.Extensions[j].Value, tc.extensions[j])
+				}
+			}
+		}
+	}
+}
+
+func TestExtensionsLister(t *testing.T) {
+	testCases := []struct {
+		lister     extensionsLister
+		length     int
+		err        bool
+		extensions []report.Extension
+	}{
+		{
+			lister: fileExtensionsLister(""),
+			length: 0,
+			err:    false,
+		},
+		{
+			lister: fileExtensionsLister("/path/to/extensions/does/not/exist"),
+			length: 0,
+			err:    true,
+		},
+		{
+			lister: byteExtensionsLister([]byte{}),
+			length: 0,
+			err:    false,
+		},
+		{
+			lister: byteExtensionsLister([]byte("fake extensions data")),
+			length: 0,
+			err:    true,
+		},
+		{
+			lister: byteExtensionsLister([]byte{}),
+			length: 0,
+			err:    false,
+		},
+		{
+			lister: byteExtensionsLister([]byte(`{"foo":"bar"}`)),
+			length: 1,
+			err:    false,
+			extensions: []report.Extension{
+				{
+					Name:  "foo",
+					Value: "bar",
+				},
+			},
+		},
+		{
+			lister: byteExtensionsLister([]byte(`{"foo":"bar", "baz":"qux"}`)),
+			length: 2,
+			err:    false,
+			extensions: []report.Extension{
+				{
+					Name:  "foo",
+					Value: "bar",
+				},
+				{
+					Name:  "baz",
+					Value: "qux",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		l := tc.lister
+		extensions, err := l.ListExtensions()
+
+		if tc.err {
+			if err == nil {
+				t.Errorf("[%d] expected error, got %v", i, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("[%d] unexpected error %q", i, err)
+			}
+		}
+
+		if len(extensions) != tc.length {
+			t.Errorf("[%d] expected %d extensions, got %d", i, tc.length, len(extensions))
+		}
+
+		if tc.extensions != nil {
+			for _, tce := range tc.extensions {
+				var extensionsContaintsTestExtension bool
+				for _, e := range extensions {
+					if e == tce {
+						extensionsContaintsTestExtension = true
+						break
+					}
+				}
+				if !extensionsContaintsTestExtension {
+					t.Errorf("[%d] expected extensions to contain %v", i, tce)
 				}
 			}
 		}

--- a/pkg/volunteer/volunteer_test.go
+++ b/pkg/volunteer/volunteer_test.go
@@ -168,12 +168,12 @@ func TestExtensionsLister(t *testing.T) {
 		extensions []report.Extension
 	}{
 		{
-			lister: fileExtensionsLister(""),
+			lister: pathExtensionsLister(""),
 			length: 0,
 			err:    false,
 		},
 		{
-			lister: fileExtensionsLister("/path/to/extensions/does/not/exist"),
+			lister: pathExtensionsLister("/path/to/extensions/does/not/exist"),
 			length: 0,
 			err:    true,
 		},


### PR DESCRIPTION
This pull request adds extensions reporting capabilities to the volunteer
and collector. This addresses #10 by giving users the option to report
metrics from a JSON file that can either be static or dynamically generated 
by a sidecar running alongside the volunteer.

Reports can be voluntarily extended to include additional information by
running the volunteer with the `--extensions` flag.  This flag should be set to
the path of a file of arbitrary JSON key-value pairs you would like to report,
e.g.:

```
spartakus volunteer --cluster-id=$(uuidgen) --extensions=/path/to/my/extensions.json
```

Where `extensions.json` could be:

```json
{
  "hello": "world",
  "foo": "bar"
}
```

With this configuration, the volunteer will generate a report that looks like:

```json
{
    "version": "v1.0.0",
    "timestamp": "867530909031976",
    "clusterID": "2f9c93d3-156c-47aa-8802-578ffca9b50e",
    "masterVersion": "v1.3.5",
    "extensions": [
      {
        "name": "hello",
        "value": "world"
      },
      {
        "name": "foo",
        "value": "bar"
      }
    ]
}
```

/cc @philips @sym3tri @thockin 

Fixes #10 