### PR TITLE
Docs re-org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.go
 /.push-*
 /.container-*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@
 
 > Project Spartakus aims at collecting usage information about Kubernetes clusters. This information will help the Kubernetes development team to understand what people are doing with it, and to make it a better product.
 
+- [What is in a report?](#what-is-in-a-report)
+- [How do I run it?](#how-do-i-run-it)
+- [What will we do with this information?](#what-will-we-do-with-this-information)
+- [User documentation](docs/)
+- [Development](#development)
+- [Future](#future)
+
 Note: **Spartakus does not report any personal identifiable information (PII)**.  Anything that might be identifying, including IP addresses, container images, and object names are anonymized. We take this very seriously. If you think something we are collecting might be considered PII, please doe let us know by raising an issue here.
 
-Running Spartakus is a voluntary effort, that is, itis not baked into Kubernetes in any way, shape, or form. In other words: it operates on an opt-in basis—if you don't want to run it, you don't have to. If you want to run your own server and collect data yourself, you can do that, too—see also the [user docs](docs/) for more info on how to customize the reports.  
+Running Spartakus is a voluntary effort, that is, it is not baked into Kubernetes in any way, shape, or form. In other words: it operates on an opt-in basis—if you don't want to run it, you don't have to. If you want to run your own server and collect data yourself, you can do that, too—see also the [user docs](docs/) for more info on how to customize the reports.  
 
 ## What is in a report?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,79 @@
+# Spartakus User Documentation
+
+If you prefer a hands-on experience over reading a lot of text, check out the [Spartakus walk-through](walk-through.md), otherwise read on.
+
+## Terminology
+
+In Spartakus we differentiate between two roles (both supported by the same program):
+
+- A **volunteer** periodically generates reports using the Kubernetes API and publishes it to the collector.
+- A **collector** receives reports from volunteers and stores them in a reporting back-end (default: Google BigQuery).
+
+Each cluster you're reporting on is uniquely identified by a user-provided cluster identifier.
+
+## Commands
+
+## Extensions
+
+Reports can be extended to include additional, custom information called **extensions**. Extensions are key-value pairs with the following requirements:
+
+- Valid keys have two segments: an optional prefix and a name, separated by a slash (`/`). The name segment is required and the prefix is optional. If specified, the prefix must be a DNS sub-domain: a series of DNS labels separated by dots (`.`), e.g. "example.com".
+- The values are not restricted in terms of structure or content.
+
+In order to submit extensions, run the volunteer with the `--extensions` flag.
+This flag should be set to the path of a file of arbitrary JSON key-value pairs
+you would like to report. For example:
+
+```bash
+$ spartakus volunteer --cluster-id=$(uuidgen) \
+                      --extensions=/path/to/extensions.json
+```
+
+With `extensions.json` for example like:
+
+```json
+{
+  "example.com/hello": "world",
+  "example.com/foo": "bar"
+}
+```
+
+Using above `extensions.json` as configuration, the volunteer will generate a report that looks like something like:
+
+```json
+{
+    "version": "v1.0.0",
+    "timestamp": "867530909031976",
+    "clusterID": "2f9c93d3-156c-47aa-8802-578ffca9b50e",
+    "masterVersion": "v1.3.5",
+    "extensions": [
+      {
+        "name": "example.com/hello",
+        "value": "world"
+      },
+      {
+        "name": "example.com/foo",
+        "value": "bar"
+      }
+    ]
+}
+```
+
+Note that the `--extensions` flag can optionally be set to the path of a directory. In this case, all files in the provided directory, excluding those with a leading
+`.`, will be parsed.
+
+## Security considerations
+
+If you're using Spartakus in a cluster with RBAC enabled, you will have to create a role and a role binding as follows so that Spartakus has the appropriate permissions (essentially allowed to list nodes):
+
+```bash
+$ kubectl create role nodelister \
+        --verb=get --verb=list \
+        --resource=nodes
+
+$ kubectl create rolebinding nodelisterbinding \
+        --role=nodelister \
+        --serviceaccount=default:default
+```
+
+Note that above assumes you're running Spartakus in the default namespace.

--- a/docs/walk-through.md
+++ b/docs/walk-through.md
@@ -1,0 +1,70 @@
+# Walk-through
+
+If RBAC enabled, first make sure Spartakus has the appropriate permissions:
+
+```bash
+$ kubectl create role nodelister \
+        --verb=get --verb=list \
+        --resource=nodes
+
+$ kubectl create rolebinding nodelisterbinding \
+        --role=nodelister \
+        --serviceaccount=default:default
+```
+
+Now you can launch it:
+
+```bash
+$ kubectl run spartakus \
+    --image=gcr.io/google_containers/spartakus-amd64:v1.0.0 \
+    -- volunteer --cluster-id=$(uuidgen)
+```
+
+Check if it works properly by finding the Spartakus pod:
+
+```bash
+$ kubectl get po | grep sparta
+spartakus-76bddd7bbf-4hllm   1/1       Running   0          5m
+```
+
+… and then exec into it to call it manually:
+
+```bash
+$ kubectl exec -it spartakus-76bddd7bbf-4hllm -- sh
+~ $ /spartakus volunteer --cluster-id=1E679954-3666-4275-ACB2 --database=stdout
+I0310 05:32:03.906610      28 database.go:42] using "stdout" database
+I0310 05:32:03.907117      28 volunteer.go:65] started volunteer
+{
+    "version": "v1.0.0",
+    "timestamp": "",
+    "clusterID": "1E679954-3666-4275-ACB2",
+    "masterVersion": "v1.9.2",
+    "nodes": [
+        {
+            "id": "8158ffac04c90df934c1e47193f0d834",
+            "operatingSystem": "linux",
+            "osImage": "Docker for Mac",
+            "kernelVersion": "4.9.75-linuxkit-aufs",
+            "architecture": "amd64",
+            "containerRuntimeVersion": "docker://18.3.0",
+            "kubeletVersion": "v1.9.2",
+            "capacity": [
+                {
+                    "resource": "cpu",
+                    "value": "4"
+                },
+                {
+                    "resource": "memory",
+                    "value": "4042012Ki"
+                },
+                {
+                    "resource": "pods",
+                    "value": "110"
+                }
+            ]
+        }
+    ]
+}
+I0310 05:32:03.931955      28 volunteer.go:70] report successfully sent
+I0310 05:32:03.931975      28 volunteer.go:75] next attempt in 24h0m0s
+```


### PR DESCRIPTION
This PR re-organizes the docs:

- It introduces a new `docs/` folder (which we in turn could also use as the basis for a GitHub pages publishing process) representing the (end-)user documentation
- It moves stuff from the current README to the user docs, esp. around extensions
- It adds security considerations (RBAC)
- It adds an end-to-end walk-through, showing Spartakus in action


CC: @thockin @squat 